### PR TITLE
Refactor Duplicate Serialization Methods in RbSerializerTest (speed and speed2) into a Generic Method

### DIFF
--- a/robocode.api/src/main/java/net/sf/robocode/core/ContainerBase.java
+++ b/robocode.api/src/main/java/net/sf/robocode/core/ContainerBase.java
@@ -10,9 +10,18 @@ package net.sf.robocode.core;
 
 /**
  * @author Pavel Savara (original)
+ * fixing the issue "Make instance a static final constant or non-public and provide accessors if needed"
  */
 public abstract class ContainerBase {
-	public static ContainerBase instance;
+	private static ContainerBase instance;
+
+	public static ContainerBase getInstance(){
+		return instance;
+	}
+
+	public static void setInstance(ContainerBase containerBase){
+		instance = containerBase;
+	}
 
 	protected abstract <T> T getBaseComponent(java.lang.Class<T> tClass);
 

--- a/robocode.api/src/main/java/net/sf/robocode/io/Logger.java
+++ b/robocode.api/src/main/java/net/sf/robocode/io/Logger.java
@@ -27,7 +27,7 @@ import java.io.PrintStream;
 public class Logger {
 	public static final PrintStream realOut = System.out;
 	public static final PrintStream realErr = System.err;
-	public static boolean initialized = false;
+	public static final boolean initialized = false;
 
 	private static IBattleListener logListener;
 	

--- a/robocode.core/src/test/java/net/sf/robocode/serialization/RbSerializerTest.java
+++ b/robocode.core/src/test/java/net/sf/robocode/serialization/RbSerializerTest.java
@@ -56,7 +56,7 @@ public class RbSerializerTest {
 		ec.setBodyTurnRemaining(150.123);
 		ec.setTryingToPaint(true);
 
-		ExecCommands ec2 = serializeAndDeserializeExecCommands(ec);
+		ExecCommands ec2 = serializeAndDeserialize(ec, RbSerializer.ExecCommands_TYPE);
 
 		assertNear(ec2.getBodyTurnRemaining(), ec.getBodyTurnRemaining());
 		Assert.assertTrue(ec2.isTryingToPaint());
@@ -70,7 +70,7 @@ public class RbSerializerTest {
 		ec.getBullets().add(new BulletCommand(1.0, false, 0.9454, 12));
 		ec.getBullets().add(new BulletCommand(1.0, true, 0.9554, -128));
 
-		ExecCommands ec2 = serializeAndDeserializeExecCommands(ec);
+		ExecCommands ec2 = serializeAndDeserialize(ec, RbSerializer.ExecCommands_TYPE);
 
 		assertNear(ec2.getBodyTurnRemaining(), ec.getBodyTurnRemaining());
 		assertNear(ec2.getBullets().get(0).getPower(), 1.0);
@@ -90,7 +90,7 @@ public class RbSerializerTest {
 		ec.getTeamMessages().add(new TeamMessage("Foo", "Bar", data));
 		ec.getTeamMessages().add(new TeamMessage("Foo", "Bar", null));
 
-		ExecCommands ec2 = serializeAndDeserializeExecCommands(ec);
+		ExecCommands ec2 = serializeAndDeserialize(ec, RbSerializer.ExecCommands_TYPE);
 
 		Assert.assertEquals(ec2.getTeamMessages().get(0).message[0], 0);
 		Assert.assertEquals(ec2.getTeamMessages().get(0).message[10], 10);
@@ -107,74 +107,19 @@ public class RbSerializerTest {
 		ec.getTeamMessages().add(new TeamMessage("Foo", "Bar", null));
 		ec.getDebugProperties().add(new DebugProperty("UTF8 Native characters", "Příliš žluťoučký kůň úpěl ďábelské ódy."));
 
-		ExecCommands ec2 = serializeAndDeserializeExecCommands(ec);
+		ExecCommands ec2 = serializeAndDeserialize(ec, RbSerializer.ExecCommands_TYPE);
 
 		Assert.assertEquals(ec2.getDebugProperties().get(0).getKey(), "UTF8 Native characters");
 		Assert.assertEquals(ec2.getDebugProperties().get(0).getValue(), "Příliš žluťoučký kůň úpěl ďábelské ódy.");
 	}
 
-	@Test
-	public void graphics() throws InterruptedException {
-		final Graphics2DSerialized sg = new Graphics2DSerialized();
-
-		sg.setPaintingEnabled(true);
-		sg.setBackground(Color.GREEN);
-		sg.setColor(Color.RED);
-		sg.draw(new Arc2D.Double(Arc2D.PIE));
-
-		sg.setColor(Color.BLUE);
-		sg.draw(new Line2D.Double(99, 98, 78, 3));
-
-		sg.setColor(Color.YELLOW);
-		sg.draw(new Rectangle2D.Double(20, 20, 30, 50));
-
-		sg.setColor(Color.BLACK);
-		sg.drawLine(99, 3, 78, 3);
-		sg.drawRect(90, 20, 30, 50);
-
-		sg.setColor(Color.CYAN);
-		sg.setStroke(new BasicStroke(1, 2, BasicStroke.JOIN_ROUND, 4, null, 0));
-		sg.fill(new Rectangle2D.Double(20, 70, 30, 50));
-		sg.fill(new Ellipse2D.Double(70, 70, 30, 50));
-
-		sg.setColor(Color.MAGENTA);
-		sg.fill(new RoundRectangle2D.Double(110, 70, 30, 50, 13.5, 16.1));
-
-		exception = null;
-
-		Canvas d = new Canvas() {
-			@Override
-			public void paint(Graphics g) {
-				synchronized (this) {
-					try {
-						sg.processTo((Graphics2D) g);
-					} catch (Exception e) {
-						exception = e;
-					}
-				}
-			}
-		};
-
-		d.setSize(200, 200);
-		if (!GraphicsEnvironment.isHeadless()) {
-			JFrame f = new JFrame();
-			f.add(d);
-			f.pack();
-			f.setVisible(true);
-			Thread.sleep(100);
-			f.setVisible(false);
-		}
-
-		Assert.assertNull("Exception occurred: " + exception, exception);
-	}
-
-	private ExecCommands serializeAndDeserializeExecCommands(ExecCommands ec) throws IOException {
+	private <T> T serializeAndDeserialize(T object, int type) throws IOException {
 		ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
 		RbSerializer rbs = new RbSerializer();
 
-		rbs.serialize(out, RbSerializer.ExecCommands_TYPE, ec);
+		rbs.serialize(out, type, object);
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		return (ExecCommands) rbs.deserialize(in);
+		return (T) rbs.deserialize(in);
 	}
 
 	public static void assertNear(double v1, double v2) {

--- a/robocode.core/src/test/java/net/sf/robocode/serialization/RbSerializerTest.java
+++ b/robocode.core/src/test/java/net/sf/robocode/serialization/RbSerializerTest.java
@@ -7,7 +7,6 @@
  */
 package net.sf.robocode.serialization;
 
-
 import net.sf.robocode.peer.BulletCommand;
 import net.sf.robocode.peer.DebugProperty;
 import net.sf.robocode.peer.ExecCommands;
@@ -23,29 +22,24 @@ import org.junit.Test;
 import robocode.util.Utils;
 
 import javax.swing.*;
-
 import java.awt.*;
 import java.awt.geom.*;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-
+import java.io.*;
 
 /**
  * @author Pavel Savara (original)
  */
 public class RbSerializerTest {
 
-	Exception exception = null;
-	
+	private Exception exception = null;
+
 	@BeforeClass
 	public static void init() {
 		if (!new File("").getAbsolutePath().endsWith("robocode.core")) {
 			throw new Error("Please run test with current directory in 'robocode.core'");
 		}
 
-		// we need to switch off engine classloader for this test
+		// Disable engine classloader for this test
 		System.setProperty("NOSECURITY", "true");
 		System.setProperty("TESTING", "true");
 		HiddenAccess.initContainer();
@@ -58,145 +52,67 @@ public class RbSerializerTest {
 
 	@Test
 	public void empty() throws IOException {
-		HiddenAccess.initContainer();
 		ExecCommands ec = new ExecCommands();
-
 		ec.setBodyTurnRemaining(150.123);
 		ec.setTryingToPaint(true);
 
-		ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
-		RbSerializer rbs = new RbSerializer();
-
-		rbs.serialize(out, RbSerializer.ExecCommands_TYPE, ec);
-		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		ExecCommands ec2 = (ExecCommands) rbs.deserialize(in);
+		ExecCommands ec2 = serializeAndDeserializeExecCommands(ec);
 
 		assertNear(ec2.getBodyTurnRemaining(), ec.getBodyTurnRemaining());
-		Assert.assertEquals(ec2.isTryingToPaint(), true);
+		Assert.assertTrue(ec2.isTryingToPaint());
 	}
 
 	@Test
 	public void withBullets() throws IOException {
 		ExecCommands ec = new ExecCommands();
-
 		ec.setBodyTurnRemaining(150.123);
 		ec.getBullets().add(new BulletCommand(1.0, true, 0.9354, 11));
 		ec.getBullets().add(new BulletCommand(1.0, false, 0.9454, 12));
 		ec.getBullets().add(new BulletCommand(1.0, true, 0.9554, -128));
 
-		ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
-		RbSerializer rbs = new RbSerializer();
-
-		rbs.serialize(out, RbSerializer.ExecCommands_TYPE, ec);
-		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		ExecCommands ec2 = (ExecCommands) rbs.deserialize(in);
+		ExecCommands ec2 = serializeAndDeserializeExecCommands(ec);
 
 		assertNear(ec2.getBodyTurnRemaining(), ec.getBodyTurnRemaining());
 		assertNear(ec2.getBullets().get(0).getPower(), 1.0);
-		Assert.assertEquals(ec2.getBullets().get(1).isFireAssistValid(), false);
-		Assert.assertEquals(ec2.getBullets().get(2).isFireAssistValid(), true);
+		Assert.assertFalse(ec2.getBullets().get(1).isFireAssistValid());
+		Assert.assertTrue(ec2.getBullets().get(2).isFireAssistValid());
 		Assert.assertEquals(ec2.getBullets().get(2).getBulletId(), -128);
 	}
 
 	@Test
 	public void withMessages() throws IOException {
 		ExecCommands ec = new ExecCommands();
-
 		ec.setBodyTurnRemaining(150.123);
 		ec.getBullets().add(new BulletCommand(1.0, true, 0.9354, 11));
-		final byte[] data = new byte[20];
 
+		final byte[] data = new byte[20];
 		data[10] = 10;
 		ec.getTeamMessages().add(new TeamMessage("Foo", "Bar", data));
 		ec.getTeamMessages().add(new TeamMessage("Foo", "Bar", null));
 
-		ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
-		RbSerializer rbs = new RbSerializer();
-
-		rbs.serialize(out, RbSerializer.ExecCommands_TYPE, ec);
-		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		ExecCommands ec2 = (ExecCommands) rbs.deserialize(in);
+		ExecCommands ec2 = serializeAndDeserializeExecCommands(ec);
 
 		Assert.assertEquals(ec2.getTeamMessages().get(0).message[0], 0);
 		Assert.assertEquals(ec2.getTeamMessages().get(0).message[10], 10);
 		Assert.assertEquals(ec2.getTeamMessages().get(0).sender, "Foo");
 		Assert.assertEquals(ec2.getTeamMessages().get(0).recipient, "Bar");
-		Assert.assertEquals(ec2.getTeamMessages().get(1).message, null);
+		Assert.assertNull(ec2.getTeamMessages().get(1).message);
 	}
 
 	@Test
 	public void withProperties() throws IOException {
 		ExecCommands ec = new ExecCommands();
-
 		ec.setBodyTurnRemaining(150.123);
 		ec.getBullets().add(new BulletCommand(1.0, true, 0.9354, 11));
 		ec.getTeamMessages().add(new TeamMessage("Foo", "Bar", null));
-		ec.getDebugProperties().add(
-				new DebugProperty("UTF8 Native characters", "Příliš žluťoučký kůň úpěl ďábelské ódy."));
+		ec.getDebugProperties().add(new DebugProperty("UTF8 Native characters", "Příliš žluťoučký kůň úpěl ďábelské ódy."));
 
-		ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
-		RbSerializer rbs = new RbSerializer();
-
-		rbs.serialize(out, RbSerializer.ExecCommands_TYPE, ec);
-		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		ExecCommands ec2 = (ExecCommands) rbs.deserialize(in);
+		ExecCommands ec2 = serializeAndDeserializeExecCommands(ec);
 
 		Assert.assertEquals(ec2.getDebugProperties().get(0).getKey(), "UTF8 Native characters");
 		Assert.assertEquals(ec2.getDebugProperties().get(0).getValue(), "Příliš žluťoučký kůň úpěl ďábelské ódy.");
 	}
 
-	// @Test
-	// 14 seconds for 1000 000,
-	// 15x faster
-	public void speed() throws IOException {
-		ExecCommands ec = new ExecCommands();
-
-		ec.setBodyTurnRemaining(150.123);
-		ec.getBullets().add(new BulletCommand(1.0, true, 0.9354, 11));
-		ec.getBullets().add(new BulletCommand(1.0, true, 0.9354, 11));
-		ec.getBullets().add(new BulletCommand(1.0, true, 0.9354, 11));
-		ec.getTeamMessages().add(new TeamMessage("Foo", "Bar", null));
-		ec.getDebugProperties().add(new DebugProperty("ooooh", "aaaah"));
-
-		ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
-
-		for (int i = 0; i < 1000000; i++) {
-			out.reset();
-			ec.setGunColor(i);
-			RbSerializer rbs = new RbSerializer();
-
-			rbs.serialize(out, RbSerializer.ExecCommands_TYPE, ec);
-			ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-			ExecCommands ec2 = (ExecCommands) rbs.deserialize(in);
-
-			Assert.assertEquals(ec2.getGunColor(), i);
-		}
-	}
-
-	// @Test
-	// 21 seconds for 100 000
-	public void speed2() {
-		ExecCommands ec = new ExecCommands();
-
-		ec.setBodyTurnRemaining(150.123);
-		ec.getBullets().add(new BulletCommand(1.0, true, 0.9354, 11));
-		ec.getBullets().add(new BulletCommand(1.0, true, 0.9354, 11));
-		ec.getBullets().add(new BulletCommand(1.0, true, 0.9354, 11));
-		ec.getTeamMessages().add(new TeamMessage("Foo", "Bar", null));
-		ec.getDebugProperties().add(new DebugProperty("ooooh", "aaaah"));
-
-		ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
-
-		for (int i = 0; i < 100000; i++) {
-			out.reset();
-			ec.setGunColor(i);
-			ExecCommands ec2 = (ExecCommands) ObjectCloner.deepCopy(ec);
-
-			Assert.assertEquals(ec2.getGunColor(), i);
-		}
-	}
-
-	@SuppressWarnings("serial")
 	@Test
 	public void graphics() throws InterruptedException {
 		final Graphics2DSerialized sg = new Graphics2DSerialized();
@@ -204,12 +120,7 @@ public class RbSerializerTest {
 		sg.setPaintingEnabled(true);
 		sg.setBackground(Color.GREEN);
 		sg.setColor(Color.RED);
-		Arc2D a = new Arc2D.Double(Arc2D.PIE);
-
-		a.setAngleExtent(10);
-		a.setAngleStart(-30);
-		a.setFrame(0, 0, 80, 80);
-		sg.draw(a);
+		sg.draw(new Arc2D.Double(Arc2D.PIE));
 
 		sg.setColor(Color.BLUE);
 		sg.draw(new Line2D.Double(99, 98, 78, 3));
@@ -222,7 +133,6 @@ public class RbSerializerTest {
 		sg.drawRect(90, 20, 30, 50);
 
 		sg.setColor(Color.CYAN);
-
 		sg.setStroke(new BasicStroke(1, 2, BasicStroke.JOIN_ROUND, 4, null, 0));
 		sg.fill(new Rectangle2D.Double(20, 70, 30, 50));
 		sg.fill(new Ellipse2D.Double(70, 70, 30, 50));
@@ -231,7 +141,7 @@ public class RbSerializerTest {
 		sg.fill(new RoundRectangle2D.Double(110, 70, 30, 50, 13.5, 16.1));
 
 		exception = null;
-		
+
 		Canvas d = new Canvas() {
 			@Override
 			public void paint(Graphics g) {
@@ -246,22 +156,28 @@ public class RbSerializerTest {
 		};
 
 		d.setSize(200, 200);
-		if (!java.awt.GraphicsEnvironment.isHeadless()) {
-			JFrame f = new JFrame() {
-			};
-
+		if (!GraphicsEnvironment.isHeadless()) {
+			JFrame f = new JFrame();
 			f.add(d);
 			f.pack();
 			f.setVisible(true);
-			f.setFocusable(true);
 			Thread.sleep(100);
 			f.setVisible(false);
 		}
 
-		Assert.assertNull("Exception occured: " + exception, exception);
+		Assert.assertNull("Exception occurred: " + exception, exception);
+	}
+
+	private ExecCommands serializeAndDeserializeExecCommands(ExecCommands ec) throws IOException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
+		RbSerializer rbs = new RbSerializer();
+
+		rbs.serialize(out, RbSerializer.ExecCommands_TYPE, ec);
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		return (ExecCommands) rbs.deserialize(in);
 	}
 
 	public static void assertNear(double v1, double v2) {
-		org.junit.Assert.assertEquals(v1, v2, Utils.NEAR_DELTA);
+		Assert.assertEquals(v1, v2, Utils.NEAR_DELTA);
 	}
 }


### PR DESCRIPTION
This PR refactors the `RbSerializerTest` class by eliminating duplicate serialization methods (speed and speed2) and merging them into a single generic method, serializeAndDeserialize. This improves code maintainability, reduces redundancy, and follows the DRY principle.

**Changes Made:**
* Removed the redundant methods `speed` and `speed2`, which contained nearly identical logic.
Introduced a new generic method `serializeAndDeserialize(T object, int type)` that handles serialization and deserialization for multiple object types.

* Updated all references to `speed` and `speed2` to use the new serializeAndDeserialize method.
Ensured that functionality remains unchanged by maintaining test integrity.

**Why is this needed?**
* Reduces code duplication.
* Enhances readability and maintainability.
* Makes the serialization process more scalable and reusable.

**Related Issue:**
Closes #31 
