### PR TITLE
Fix/secure delete old libs

### DIFF
--- a/robocode.api/src/main/java/net/sf/robocode/core/ContainerBase.java
+++ b/robocode.api/src/main/java/net/sf/robocode/core/ContainerBase.java
@@ -13,7 +13,7 @@ package net.sf.robocode.core;
  * fixing the issue "Make instance a static final constant or non-public and provide accessors if needed"
  */
 public abstract class ContainerBase {
-	private static ContainerBase instance;
+	 static ContainerBase instance;
 
 	public static ContainerBase getInstance(){
 		return instance;

--- a/robocode.api/src/main/java/net/sf/robocode/core/ContainerBase.java
+++ b/robocode.api/src/main/java/net/sf/robocode/core/ContainerBase.java
@@ -10,9 +10,18 @@ package net.sf.robocode.core;
 
 /**
  * @author Pavel Savara (original)
+ * fixing the issue "Make instance a static final constant or non-public and provide accessors if needed"
  */
 public abstract class ContainerBase {
-	public static ContainerBase instance;
+	private static ContainerBase instance;
+
+	public static ContainerBase getInstance(){
+		return instance;
+	}
+
+	public static void setInstance(ContainerBase containerBase){
+		instance = containerBase;
+	}
 
 	protected abstract <T> T getBaseComponent(java.lang.Class<T> tClass);
 

--- a/robocode.api/src/main/java/net/sf/robocode/io/Logger.java
+++ b/robocode.api/src/main/java/net/sf/robocode/io/Logger.java
@@ -27,7 +27,7 @@ import java.io.PrintStream;
 public class Logger {
 	public static final PrintStream realOut = System.out;
 	public static final PrintStream realErr = System.err;
-	public static final boolean initialized = false;
+	public static boolean initialized = false;
 
 	private static IBattleListener logListener;
 	

--- a/robocode.api/src/main/java/net/sf/robocode/io/Logger.java
+++ b/robocode.api/src/main/java/net/sf/robocode/io/Logger.java
@@ -27,7 +27,7 @@ import java.io.PrintStream;
 public class Logger {
 	public static final PrintStream realOut = System.out;
 	public static final PrintStream realErr = System.err;
-	public static boolean initialized = false;
+	public static final boolean initialized = false;
 
 	private static IBattleListener logListener;
 	

--- a/robocode.installer/src/main/java/net/sf/robocode/installer/AutoExtract.java
+++ b/robocode.installer/src/main/java/net/sf/robocode/installer/AutoExtract.java
@@ -495,8 +495,6 @@ public class AutoExtract implements ActionListener {
             System.err.println("Error while deleting old libs: " + e.getMessage());
         }
     }
-
-
     public static boolean deleteRecursively(File file) {
         if (file.isDirectory()) {
             File[] children = file.listFiles();


### PR DESCRIPTION
This pull request addresses a potential path traversal vulnerability in the deleteOldLibs() method, where unsanitized file paths could be exploited to delete files outside the intended libs directory.

**Changes Made**
Resolved installDir/libs and all target files using getCanonicalFile() to normalize paths.

Added validation to ensure each file being deleted resides within the expected libs directory.

Implemented safe recursive deletion for nested directories or contents.

Improved logging for deletion attempts, successes, and failures.

Handled null values from listFiles() safely.


**Affected Area**
deleteOldLibs(File installDir) method

Added deleteRecursively(File file) helper for safe file removal
