### PR TITLE
RobotFileSystemManager file name vulnerability & JarExtractor Path Traversal vurnerability

### DIFF
--- a/robocode.api/src/main/java/robocode/KeyEvent.java
+++ b/robocode.api/src/main/java/robocode/KeyEvent.java
@@ -41,4 +41,60 @@ public abstract class KeyEvent extends Event {
 		return source;
 	}
 
+	private static class SerializableHelper implements ISerializableHelper {
+
+		private static void serializeDetails(RbSerializer serializer, ByteBuffer buffer, java.awt.event.KeyEvent event) {
+			serializer.serialize(buffer, event.getKeyChar());
+			serializer.serialize(buffer, event.getKeyCode());
+			serializer.serialize(buffer, event.getKeyLocation());
+			serializer.serialize(buffer, event.getID());
+			serializer.serialize(buffer, event.getModifiersEx());
+			serializer.serialize(buffer, event.getWhen());
+		}
+
+		private static java.awt.event.KeyEvent deserializeDetails(ByteBuffer buffer) {
+			char keyChar = buffer.getChar();
+			int keyCode = buffer.getInt();
+			int keyLocation = buffer.getInt();
+			int id = buffer.getInt();
+			int modifiersEx = buffer.getInt();
+			long when = buffer.getLong();
+
+			return new java.awt.event.KeyEvent(SafeComponent.getSafeEventComponent(), id, when, modifiersEx, keyCode, keyChar, keyLocation);
+		}
+
+		public int sizeOf(RbSerializer serializer, Object object) {
+			return RbSerializer.SIZEOF_TYPEINFO + RbSerializer.SIZEOF_CHAR + RbSerializer.SIZEOF_INT
+					+ RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_LONG + RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_INT;
+		}
+
+		public void serialize(RbSerializer serializer, ByteBuffer buffer, Object object) {
+			if (object instanceof KeyTypedEvent) {
+				serializeDetails(serializer, buffer, ((KeyTypedEvent) object).getSourceEvent());
+			} else if (object instanceof KeyPressedEvent) {
+				serializeDetails(serializer, buffer, ((KeyPressedEvent) object).getSourceEvent());
+			} else if (object instanceof KeyReleasedEvent) {
+				serializeDetails(serializer, buffer, ((KeyReleasedEvent) object).getSourceEvent());
+			} else {
+				throw new IllegalArgumentException("Unsupported event type: " + object.getClass().getName());
+			}
+
+		}
+
+		public Object deserialize(RbSerializer serializer, ByteBuffer buffer) {
+			java.awt.event.KeyEvent event = deserializeDetails(buffer);
+
+			// Determine the correct event type
+			switch (event.getID()) {
+				case java.awt.event.KeyEvent.KEY_TYPED:
+					return new KeyTypedEvent(event);
+				case java.awt.event.KeyEvent.KEY_PRESSED:
+					return new KeyPressedEvent(event);
+				case java.awt.event.KeyEvent.KEY_RELEASED:
+					return new KeyReleasedEvent(event);
+				default:
+					throw new IllegalArgumentException("Unknown key event type: " + event.getID());
+			}
+		}
+	}
 }

--- a/robocode.api/src/main/java/robocode/KeyEvent.java
+++ b/robocode.api/src/main/java/robocode/KeyEvent.java
@@ -8,6 +8,12 @@
 package robocode;
 
 
+import net.sf.robocode.security.SafeComponent;
+import net.sf.robocode.serialization.ISerializableHelper;
+import net.sf.robocode.serialization.RbSerializer;
+
+import java.nio.ByteBuffer;
+
 /**
  * Super class of all events that originates from the keyboard.
  *
@@ -41,7 +47,7 @@ public abstract class KeyEvent extends Event {
 		return source;
 	}
 
-	private static class SerializableHelper implements ISerializableHelper {
+	protected static class SerializableHelper implements ISerializableHelper {
 
 		private static void serializeDetails(RbSerializer serializer, ByteBuffer buffer, java.awt.event.KeyEvent event) {
 			serializer.serialize(buffer, event.getKeyChar());

--- a/robocode.api/src/main/java/robocode/KeyPressedEvent.java
+++ b/robocode.api/src/main/java/robocode/KeyPressedEvent.java
@@ -78,37 +78,4 @@ public final class KeyPressedEvent extends KeyEvent {
 	static ISerializableHelper createHiddenSerializer() {
 		return new SerializableHelper();
 	}
-
-	private static class SerializableHelper implements ISerializableHelper {
-
-		public int sizeOf(RbSerializer serializer, Object object) {
-			return RbSerializer.SIZEOF_TYPEINFO + RbSerializer.SIZEOF_CHAR + RbSerializer.SIZEOF_INT
-					+ RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_LONG + RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_INT;
-		}
-
-		public void serialize(RbSerializer serializer, ByteBuffer buffer, Object object) {
-			KeyPressedEvent obj = (KeyPressedEvent) object;
-			java.awt.event.KeyEvent src = obj.getSourceEvent();
-
-			serializer.serialize(buffer, src.getKeyChar());
-			serializer.serialize(buffer, src.getKeyCode());
-			serializer.serialize(buffer, src.getKeyLocation());
-			serializer.serialize(buffer, src.getID());
-			serializer.serialize(buffer, src.getModifiersEx());
-			serializer.serialize(buffer, src.getWhen());
-		}
-
-		public Object deserialize(RbSerializer serializer, ByteBuffer buffer) {
-			char keyChar = buffer.getChar();
-			int keyCode = buffer.getInt();
-			int keyLocation = buffer.getInt();
-			int id = buffer.getInt();
-			int modifiersEx = buffer.getInt();
-			long when = buffer.getLong();
-
-			return new KeyPressedEvent(
-					new java.awt.event.KeyEvent(SafeComponent.getSafeEventComponent(), id, when, modifiersEx, keyCode, keyChar,
-					keyLocation));
-		}
-	}
 }

--- a/robocode.api/src/main/java/robocode/KeyReleasedEvent.java
+++ b/robocode.api/src/main/java/robocode/KeyReleasedEvent.java
@@ -78,37 +78,4 @@ public final class KeyReleasedEvent extends KeyEvent {
 	static ISerializableHelper createHiddenSerializer() {
 		return new SerializableHelper();
 	}
-
-	private static class SerializableHelper implements ISerializableHelper {
-
-		public int sizeOf(RbSerializer serializer, Object object) {
-			return RbSerializer.SIZEOF_TYPEINFO + RbSerializer.SIZEOF_CHAR + RbSerializer.SIZEOF_INT
-					+ RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_LONG + RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_INT;
-		}
-
-		public void serialize(RbSerializer serializer, ByteBuffer buffer, Object object) {
-			KeyReleasedEvent obj = (KeyReleasedEvent) object;
-			java.awt.event.KeyEvent src = obj.getSourceEvent();
-
-			serializer.serialize(buffer, src.getKeyChar());
-			serializer.serialize(buffer, src.getKeyCode());
-			serializer.serialize(buffer, src.getKeyLocation());
-			serializer.serialize(buffer, src.getID());
-			serializer.serialize(buffer, src.getModifiersEx());
-			serializer.serialize(buffer, src.getWhen());
-		}
-
-		public Object deserialize(RbSerializer serializer, ByteBuffer buffer) {
-			char keyChar = buffer.getChar();
-			int keyCode = buffer.getInt();
-			int keyLocation = buffer.getInt();
-			int id = buffer.getInt();
-			int modifiersEx = buffer.getInt();
-			long when = buffer.getLong();
-
-			return new KeyReleasedEvent(
-					new java.awt.event.KeyEvent(SafeComponent.getSafeEventComponent(), id, when, modifiersEx, keyCode, keyChar,
-					keyLocation));
-		}
-	}
 }

--- a/robocode.api/src/main/java/robocode/KeyTypedEvent.java
+++ b/robocode.api/src/main/java/robocode/KeyTypedEvent.java
@@ -78,37 +78,4 @@ public final class KeyTypedEvent extends KeyEvent {
 	static ISerializableHelper createHiddenSerializer() {
 		return new SerializableHelper();
 	}
-
-	private static class SerializableHelper implements ISerializableHelper {
-
-		public int sizeOf(RbSerializer serializer, Object object) {
-			return RbSerializer.SIZEOF_TYPEINFO + RbSerializer.SIZEOF_CHAR + RbSerializer.SIZEOF_INT
-					+ RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_LONG + RbSerializer.SIZEOF_INT + RbSerializer.SIZEOF_INT;
-		}
-
-		public void serialize(RbSerializer serializer, ByteBuffer buffer, Object object) {
-			KeyTypedEvent obj = (KeyTypedEvent) object;
-			java.awt.event.KeyEvent src = obj.getSourceEvent();
-
-			serializer.serialize(buffer, src.getKeyChar());
-			serializer.serialize(buffer, src.getKeyCode());
-			serializer.serialize(buffer, src.getKeyLocation());
-			serializer.serialize(buffer, src.getID());
-			serializer.serialize(buffer, src.getModifiersEx());
-			serializer.serialize(buffer, src.getWhen());
-		}
-
-		public Object deserialize(RbSerializer serializer, ByteBuffer buffer) {
-			char keyChar = buffer.getChar();
-			int keyCode = buffer.getInt();
-			int keyLocation = buffer.getInt();
-			int id = buffer.getInt();
-			int modifiersEx = buffer.getInt();
-			long when = buffer.getLong();
-
-			return new KeyTypedEvent(
-					new java.awt.event.KeyEvent(SafeComponent.getSafeEventComponent(), id, when, modifiersEx, keyCode, keyChar,
-					keyLocation));
-		}
-	}
 }

--- a/robocode.battle/src/main/java/net/sf/robocode/battle/peer/RobotPeer.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/peer/RobotPeer.java
@@ -1107,25 +1107,10 @@ public final class RobotPeer implements IRobotPeerBattle, IRobotPeer {
 		if (hitWall) {
 			addEvent(new HitWallEvent(angle));
 
-			// only fix both x and y values if hitting wall at an angle
-			if ((bodyHeading % (Math.PI / 2)) != 0) {
-				double tanHeading = tan(bodyHeading);
+			AngleCollisionAdjustment result = checkAngleWallCollision(adjustX, adjustY);
 
-				// if it hits bottom or top wall
-				if (adjustX == 0) {
-					adjustX = adjustY * tanHeading;
-				} // if it hits a side wall
-				else if (adjustY == 0) {
-					adjustY = adjustX / tanHeading;
-				} // if the robot hits 2 walls at the same time (rare, but just in case)
-				else if (abs(adjustX / tanHeading) > abs(adjustY)) {
-					adjustY = adjustX / tanHeading;
-				} else if (abs(adjustY * tanHeading) > abs(adjustX)) {
-					adjustX = adjustY * tanHeading;
-				}
-			}
-			x += adjustX;
-			y += adjustY;
+			x += result.adjustX;
+			y += result.adjustY;
 
 			if (x < minX) {
 				x = minX;
@@ -1192,26 +1177,10 @@ public final class RobotPeer implements IRobotPeerBattle, IRobotPeer {
 		if (hitWall) {
 			addEvent(new HitWallEvent(angle));
 
-			// only fix both x and y values if hitting wall at an angle
-			if ((bodyHeading % (Math.PI / 2)) != 0) {
-				double tanHeading = tan(bodyHeading);
+			AngleCollisionAdjustment result = checkAngleWallCollision(adjustX, adjustY);
 
-				// if it hits bottom or top wall
-				if (adjustX == 0) {
-					adjustX = adjustY * tanHeading;
-				} // if it hits a side wall
-				else if (adjustY == 0) {
-					adjustY = adjustX / tanHeading;
-				} // if the robot hits 2 walls at the same time (rare, but just in case)
-				else if (abs(adjustX / tanHeading) > abs(adjustY)) {
-					adjustY = adjustX / tanHeading;
-				} else if (abs(adjustY * tanHeading) > abs(adjustX)) {
-					adjustX = adjustY * tanHeading;
-				}
-			}
-
-			x += adjustX;
-			y += adjustY;
+			x += result.adjustX;
+			y += result.adjustY;
 
 			if (isOutsideBorder) {
 				if ((x - minX) <= Rules.MAX_VELOCITY) {
@@ -1237,6 +1206,37 @@ public final class RobotPeer implements IRobotPeerBattle, IRobotPeer {
 			velocity = 0;
 
 			setState(RobotState.HIT_WALL);
+		}
+	}
+
+	private AngleCollisionAdjustment checkAngleWallCollision(double adjustX, double adjustY) {
+		// only fix both x and y values if hitting wall at an angle
+		if ((bodyHeading % (Math.PI / 2)) != 0) {
+			double tanHeading = tan(bodyHeading);
+
+			// if it hits bottom or top wall
+			if (adjustX == 0) {
+				adjustX = adjustY * tanHeading;
+			} // if it hits a side wall
+			else if (adjustY == 0) {
+				adjustY = adjustX / tanHeading;
+			} // if the robot hits 2 walls at the same time (rare, but just in case)
+			else if (abs(adjustX / tanHeading) > abs(adjustY)) {
+				adjustY = adjustX / tanHeading;
+			} else if (abs(adjustY * tanHeading) > abs(adjustX)) {
+				adjustX = adjustY * tanHeading;
+			}
+		}
+        return new AngleCollisionAdjustment(adjustX, adjustY);
+	}
+
+	private static class AngleCollisionAdjustment {
+		public final double adjustX;
+		public final double adjustY;
+
+		public AngleCollisionAdjustment(double adjustX, double adjustY) {
+			this.adjustX = adjustX;
+			this.adjustY = adjustY;
 		}
 	}
 

--- a/robocode.host/src/main/java/net/sf/robocode/host/io/RobotFileSystemManager.java
+++ b/robocode.host/src/main/java/net/sf/robocode/host/io/RobotFileSystemManager.java
@@ -295,7 +295,18 @@ public class RobotFileSystemManager {
 				os = null;
 				try {
 					is = jarFile.getInputStream(jarEntry);
-					os = new FileOutputStream(new File(parent, filename));
+
+					// Secure path handling
+					File outputFile = new File(parent, filename);
+					String canonicalParentPath = parent.getCanonicalPath() + File.separator;
+					String canonicalOutputPath = outputFile.getCanonicalPath();
+
+					// Ensure the output file is within the parent directory
+					if (!canonicalOutputPath.startsWith(canonicalParentPath)) {
+						throw new IOException("Invalid entry: " + filename);
+					}
+
+					os = new FileOutputStream(outputFile);
 					copyStream(is, os);
 				} finally {
 					FileUtil.cleanupStream(is);

--- a/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/packager/JarExtractor.java
@@ -68,6 +68,16 @@ public class JarExtractor {
 		File out = new File(dest, entry.getName());
 		File parentDirectory = new File(out.getParent());
 
+		String canonicalTopParentPath = dest.getCanonicalPath() + File.separator;
+		String canonicalParentPath = parentDirectory.getCanonicalPath();
+		String canonicalOutputPath = out.getCanonicalPath();
+
+		// Ensure the output file is within the top parent directory
+		if (!canonicalParentPath.startsWith(canonicalTopParentPath)
+				|| !canonicalOutputPath.startsWith(canonicalTopParentPath)) {
+			throw new IOException("Invalid entry: " + out);
+		}
+
 		if (!parentDirectory.exists() && !parentDirectory.mkdirs()) {
 			Logger.logError("Cannot create dir: " + parentDirectory);
 		}


### PR DESCRIPTION
### RobotFileSystemManager  file name:

**Describe the Software vulnerability**
Extracting archives should not lead to zip slip vulnerabilities

**Expected behavior**
Zip slip is a special case of path injection. It occurs when an application uses the name of an archive entry to construct a file path and access this file without validating its path first. This rule will consider all archives untrusted, assuming they have been created outside the application file system. A user with malicious intent would inject specially crafted values, such as ../, in the archive entry name to change the initial intended path. The resulting path would resolve somewhere in the filesystem where the user should not normally have access.

**What is the potential impact?**
A web application is vulnerable to Zip Slip and an attacker is able to exploit it by submitting an archive he controls. The files that can be affected are limited by the permission of the process that runs the application. Worst case scenario: the process runs with root privileges on Linux, and therefore any file can be affected.

**Screenshots**
original code:
![Image](https://github.com/user-attachments/assets/040182fe-6d04-4ff9-8413-c535ebdd29eb)

solution:
![Image](https://github.com/user-attachments/assets/b38c0515-9871-4e73-8a51-cc4bbb1abfdc)

### JarExtractor Path Traversal 
Describe the Software vulnerability
Unsanitized input from a zip file flows into mkdirs, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to manipulate arbitrary files.

Expected behavior
Input from a zip file should be sanitized before being used as a path.

What is the potential impact?
The application could be manipulated into overwriting any file it has permissions for by passing a compromised jar file to the function. This could allow RCE.

Screenshots
original code:

![Image](https://github.com/user-attachments/assets/79fe4858-48eb-43cf-9cfd-1dede883785a)


solution:

![Image](https://github.com/user-attachments/assets/ff48e970-b7a9-49a1-9305-daff286df6a4)